### PR TITLE
feat: Happy Hare - Added Sync-Feedback buffer visualization and support for proportional…

### DIFF
--- a/src/components/panels/Mmu/MmuFilamentStatus.vue
+++ b/src/components/panels/Mmu/MmuFilamentStatus.vue
@@ -11,6 +11,24 @@
                 <path d="M13,8.24,18,15H15H8Z" stroke-width="2" />
             </g>
             <g
+                id="sync-feedback-buffer-piston"
+                fill="none"
+                style="stroke: var(--color-outline); fill: var(--color-outline)">
+                <rect x="3" y="0" width="30" height="40" rx="3" ry="3" fill="none" stroke-width="1.5" />
+                <path d="M-15 -4 L-6 0 L-15 4 Z" stroke-width="1" fill-opacity="0.6" />
+                <path d="M8 40 L 28 40" stroke-width="4" />
+            </g>
+            <g
+                id="sync-feedback-buffer-box"
+                fill="none"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                style="stroke: var(--color-outline)">
+                <rect x="0" y="0" width="36" height="45" rx="3" ry="3" class="fil-background" stroke-width="2" fill-opacity="0.6" />
+                <path d="M-3 10 0 10 M-3 22 0.5 22 M-3 34.5 0 34.5" stroke-width="2" stroke-opacity="0.6" />
+                <path d="M8 0 L 28 0" stroke-width="4" />
+            </g>
+            <g
                 id="sissors"
                 fill="none"
                 stroke-linecap="round"
@@ -407,6 +425,14 @@ svg text {
 
 html.theme--light .zone-background {
     fill: var(--zone-background-light-theme);
+}
+
+.fil-background {
+    fill: var(--background-dark-theme);
+}
+
+html.theme--light .fil-background {
+    fill: var(--background-light-theme);
 }
 
 .tool-text {

--- a/src/components/panels/Mmu/MmuFilamentStatus.vue
+++ b/src/components/panels/Mmu/MmuFilamentStatus.vue
@@ -24,7 +24,16 @@
                 stroke-linecap="round"
                 stroke-linejoin="round"
                 style="stroke: var(--color-outline)">
-                <rect x="0" y="0" width="36" height="45" rx="3" ry="3" class="fil-background" stroke-width="2" fill-opacity="0.6" />
+                <rect
+                    x="0"
+                    y="0"
+                    width="36"
+                    height="45"
+                    rx="3"
+                    ry="3"
+                    class="fil-background"
+                    stroke-width="2"
+                    fill-opacity="0.6" />
                 <path d="M-3 10 0 10 M-3 22 0.5 22 M-3 34.5 0 34.5" stroke-width="2" stroke-opacity="0.6" />
                 <path d="M8 0 L 28 0" stroke-width="4" />
             </g>

--- a/src/components/panels/Mmu/MmuFilamentStatusSyncFeedback.vue
+++ b/src/components/panels/Mmu/MmuFilamentStatusSyncFeedback.vue
@@ -1,6 +1,7 @@
 <template>
     <g v-if="hasSyncFeedback">
-        <use xlink:href="#sync-feedback-buffer-piston"
+        <use
+xlink:href="#sync-feedback-buffer-piston"
              :style="{transform: `translate(232px, ${syncFeedbackPistonPos}px)`, transition: 'transform 250ms ease'}" />
         <use xlink:href="#sync-feedback-buffer-box" transform="translate(232, 212)" />
         <g v-if="syncFeedbackActive">

--- a/src/components/panels/Mmu/MmuFilamentStatusSyncFeedback.vue
+++ b/src/components/panels/Mmu/MmuFilamentStatusSyncFeedback.vue
@@ -1,8 +1,11 @@
 <template>
     <g v-if="hasSyncFeedback">
         <use
-xlink:href="#sync-feedback-buffer-piston"
-             :style="{transform: `translate(232px, ${syncFeedbackPistonPos}px)`, transition: 'transform 250ms ease'}" />
+            xlink:href="#sync-feedback-buffer-piston"
+            :style="{
+                transform: `translate(232px, ${syncFeedbackPistonPos}px)`,
+                transition: 'transform 250ms ease',
+            }" />
         <use xlink:href="#sync-feedback-buffer-box" transform="translate(232, 212)" />
         <g v-if="syncFeedbackActive">
             <transition name="fade">
@@ -33,16 +36,11 @@ import MmuMixin, { FILAMENT_POS_END_BOWDEN } from '@/components/mixins/mmu'
 @Component
 export default class MmuFilamentStatusSyncFeedback extends Mixins(BaseMixin, MmuMixin) {
     get hasSyncFeedback(): boolean {
-        return (
-            this.hasFilamentCompressionSensor || this.hasFilamentTensionSensor || this.hasFilamentProportionalSensor
-        )
+        return this.hasFilamentCompressionSensor || this.hasFilamentTensionSensor || this.hasFilamentProportionalSensor
     }
 
     get syncFeedbackActive(): boolean {
-        return (
-            this.hasSyncFeedback &&
-            this.mmuFilamentPos >= FILAMENT_POS_END_BOWDEN
-        )
+        return this.hasSyncFeedback && this.mmuFilamentPos >= FILAMENT_POS_END_BOWDEN
     }
 
     get syncFeedbackEnabled() {

--- a/src/components/panels/Mmu/MmuFilamentStatusSyncFeedback.vue
+++ b/src/components/panels/Mmu/MmuFilamentStatusSyncFeedback.vue
@@ -1,21 +1,26 @@
 <template>
     <g v-if="hasSyncFeedback">
-        <transition name="fade">
-            <g v-if="filamentTensionSensor && filamentCompressionSensor" key="neutral">
-                <text x="288" y="240">Neutral</text>
-                <use xlink:href="#sync-feedback" transform="translate(286, 247.5) scale(1.0,-1.0) rotate(90)" />
-            </g>
-            <g v-else-if="filamentTensionSensor" key="tension">
-                <text x="288" y="240">Tension</text>
-                <use xlink:href="#sync-feedback" transform="translate(258, 199) scale(1.2)" />
-                <use xlink:href="#sync-feedback" transform="translate(258, 271) scale(1.2,-1.2)" />
-            </g>
-            <g v-else-if="filamentCompressionSensor" key="compression">
-                <text x="288" y="240">Compression</text>
-                <use xlink:href="#sync-feedback" transform="translate(258, 235) scale(1.2)" />
-                <use xlink:href="#sync-feedback" transform="translate(258, 235) scale(1.2,-1.2)" />
-            </g>
-        </transition>
+        <use xlink:href="#sync-feedback-buffer-piston"
+             :style="{transform: `translate(232px, ${syncFeedbackPistonPos}px)`, transition: 'transform 250ms ease'}" />
+        <use xlink:href="#sync-feedback-buffer-box" transform="translate(232, 212)" />
+        <g v-if="syncFeedbackActive">
+            <transition name="fade">
+                <g v-if="filamentTensionSensor && filamentCompressionSensor" key="neutral">
+                    <text x="298" y="240">Neutral</text>
+                    <use xlink:href="#sync-feedback" transform="translate(296, 247.5) scale(1.0,-1.0) rotate(90)" />
+                </g>
+                <g v-else-if="filamentTensionSensor" key="tension">
+                    <text x="298" y="240">Tension</text>
+                    <use xlink:href="#sync-feedback" transform="translate(272, 199) scale(1.2)" />
+                    <use xlink:href="#sync-feedback" transform="translate(272, 271) scale(1.2,-1.2)" />
+                </g>
+                <g v-else-if="filamentCompressionSensor" key="compression">
+                    <text x="298" y="240">Compression</text>
+                    <use xlink:href="#sync-feedback" transform="translate(272, 235) scale(1.2)" />
+                    <use xlink:href="#sync-feedback" transform="translate(272, 235) scale(1.2,-1.2)" />
+                </g>
+            </transition>
+        </g>
     </g>
 </template>
 
@@ -28,14 +33,29 @@ import MmuMixin, { FILAMENT_POS_END_BOWDEN } from '@/components/mixins/mmu'
 export default class MmuFilamentStatusSyncFeedback extends Mixins(BaseMixin, MmuMixin) {
     get hasSyncFeedback(): boolean {
         return (
-            this.syncFeedbackEnabled &&
-            (this.hasFilamentCompressionSensor || this.hasFilamentTensionSensor) &&
+            this.hasFilamentCompressionSensor || this.hasFilamentTensionSensor || this.hasFilamentProportionalSensor
+        )
+    }
+
+    get syncFeedbackActive(): boolean {
+        return (
+            this.hasSyncFeedback &&
             this.mmuFilamentPos >= FILAMENT_POS_END_BOWDEN
         )
     }
 
     get syncFeedbackEnabled() {
         return this.mmu?.sync_feedback_enabled ?? false
+    }
+
+    get syncFeedbackPistonPos(): int {
+        const bias = this.mmu?.sync_feedback_bias_modelled ?? 0.0
+        const yPos = bias * 12 + 234
+        return yPos
+    }
+
+    get hasFilamentProportionalSensor() {
+        return this.hasMmuSensor('filament_proportional')
     }
 
     get hasFilamentCompressionSensor() {


### PR DESCRIPTION
feat: Added visualization of sync-feedback "buffer" sensor to Happy Hare feature branch
<img width="302" height="281" alt="sync-feedback-buffer" src="https://github.com/user-attachments/assets/bf5d29a2-1315-4a71-97a8-f2e35d5d8e19" />

### Description
### Related Tickets & Documents
### Mobile & Desktop Screenshots/Recordings
[optional] Are there any post-deployment tasks we need to perform?
Signed-off-by: Paul Morgan [moggieuk@gmail.com](mailto:moggieuk@gmail.com)

